### PR TITLE
Add ability to keep custom route after disabling in menu

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -197,6 +197,20 @@ p {
     z-index: 998;
 }
 
+#custom-route-clear {
+    border: none;
+    background: none;
+    color: #eee;
+    font-size: 14px;
+    padding: 0;
+    margin: 0 0 5px;
+}
+
+#custom-route-clear:hover {
+    text-decoration: underline;
+    cursor: pointer;
+}
+
 @media (min-width: 1025px) {
     .side-menu {
         width: 300px;

--- a/assets/js/scripts.js
+++ b/assets/js/scripts.js
@@ -430,9 +430,12 @@ $("#tools").on("change", function()
 
 $("#custom-routes").on("change", function()
 {
+    customRouteEnabled = $("#custom-routes").val() == '1';
+});
+
+$('#custom-route-clear').click(function() {
     customRouteConnections = [];
     map.removeLayer(customRoute);
-    customRouteEnabled = $("#custom-routes").val() == '1';
 });
 
 $('#show-coordinates').on('change', function() {

--- a/index.html
+++ b/index.html
@@ -128,6 +128,10 @@
             </select>
         </div>
         <div class="input-container">
+            <span></span>
+            <button id="custom-route-clear">clear custom route</button>
+        </div>
+        <div class="input-container">
             <label for="show-coordinates">Show coordinates on click</label>
             <select class="input-day" id="show-coordinates">
                 <option value="1">Yes</option>


### PR DESCRIPTION
**Current functionality**
Users can enable custom routes and add them to the map. As soon as they disable the custom route on the menu, the route goes away.

**Proposed functionality**
Users can enable custom routes and add them to the map. If a user disables the custom route on the menu, the route will still be on the screen so they can click within the map and not add extra lines. This will also add an extra button on the menu to clear the route.

Use case:
A user creates a custom route, but they still want to click on the items so they can see the popup. Right now if they click on the items, they will add more lines to the map, therefore, messing up their custom route. This PR gives the user the ability to disable custom routes so they can click on the map without adding lines to it. If they want to add more lines, they can go, re-enable the custom routes, and return to creating lines on the map.