### PR TITLE
Updated grammar of `Ganso`.

### DIFF
--- a/langs/pt-br.json
+++ b/langs/pt-br.json
@@ -467,12 +467,12 @@
 	{"key": "egg_duck_2.desc", "value": ""},
 	{"key": "egg_duck_3.desc", "value": ""},
 
-	{"key": "egg_goose_1.name", "value": "Ovo de Ganço"},
+	{"key": "egg_goose_1.name", "value": "Ovo de Ganso"},
 	{"key": "egg_goose_1_1.desc", "value": ""},
 	{"key": "egg_goose_1_2.desc", "value": ""},
 	{"key": "egg_goose_1_3.desc", "value": ""},
 
-	{"key": "egg_goose_2.name", "value": "Ovo de Ganço"},
+	{"key": "egg_goose_2.name", "value": "Ovo de Ganso"},
 	{"key": "egg_goose_2_1.desc", "value": ""},
 	{"key": "egg_goose_2_2.desc", "value": ""},
 	{"key": "egg_goose_2_3.desc", "value": ""},


### PR DESCRIPTION
- Changed `Ganço` to `Ganso`.

According to user @Vitor-Borba72 and Google Translate:

![image](https://user-images.githubusercontent.com/55949253/66325050-df8b7b00-e926-11e9-9556-c033b131908f.png)
