### PR TITLE
Fixed missing capitalization

### DIFF
--- a/langs/menu/en-us.json
+++ b/langs/menu/en-us.json
@@ -44,5 +44,5 @@
 	{"key": "menu.custom_routes", "value": "Custom routes"},
 	{"key": "menu.import_route", "value": "Import route"},
 	{"key": "menu.export_route", "value": "Export route"},
-	{"key": "menu.treasures", "value": "Treasure maps"}
+	{"key": "menu.treasures", "value": "Treasure Maps"}
 ]


### PR DESCRIPTION
- Changed `Treasure maps` to `Treasure Maps` to bring it in line with other menu options in the settings menu