### PR TITLE
Fixed slight error in treasure map location

### DIFF
--- a/langs/item/de-de.json
+++ b/langs/item/de-de.json
@@ -31,7 +31,7 @@
 	{"key": "east_watson_treasure", 			"value": "Östlich von Watsons Hütte"},
 	{"key": "gaptooth_treasure", 				"value": "Gaptooth Breach"},
 	{"key": "hanging_rock_treasure", 			"value": "Hanging Rock"},
-	{"key": "hawks_eye_treasure", 				"value": "Hawk's Eye Creek"},
+	{"key": "hawks_eye_treasure", 				"value": "Hawks Eye Creek"},
 	{"key": "hennigans_central_treasure", 		"value": "Hennigan's Stead (Zentrum)"},
 	{"key": "hennigans_north_treasure", 		"value": "Hennigan's Stead (Norden)"},
 	{"key": "kamassa_river_treasure", 			"value": "Kamassa River"},


### PR DESCRIPTION
- Changed `Hawk's Eye Creek` to `Hawks Eye Creek` to bring it in line with the game