### PR TITLE
Fixed slight error in treasure map location

### DIFF
--- a/langs/item/en-us.json
+++ b/langs/item/en-us.json
@@ -31,7 +31,7 @@
 	{"key": "east_watson_treasure", 			"value": "East Watsons"},
 	{"key": "gaptooth_treasure", 				"value": "Gaptooth Breach"},
 	{"key": "hanging_rock_treasure", 			"value": "Hanging Rock"},
-	{"key": "hawks_eye_treasure", 				"value": "Hawk's Eye Creek"},
+	{"key": "hawks_eye_treasure", 				"value": "Hawks Eye Creek"},
 	{"key": "hennigans_central_treasure", 		"value": "Hennigan's Stead (Central)"},
 	{"key": "hennigans_north_treasure", 		"value": "Hennigan's Stead (North)"},
 	{"key": "kamassa_river_treasure", 			"value": "Kamassa River"},


### PR DESCRIPTION
- Changed `Hawk's Eye Creek` to `Hawks Eye Creek` to bring it in line with the game