### PR TITLE
Smaller scrollbar for the menu

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -10,6 +10,14 @@
     box-sizing: border-box;
 }
 
+::-webkit-scrollbar {
+    width: 3px;
+}
+
+::-webkit-scrollbar-thumb {
+    background: #eee;
+}
+
 body {
     margin: 0;
     font-size: 16px;


### PR DESCRIPTION
Minor fix to reduce the width of the scrollbar. Since Google removed the overlay scrollbars in chrome, windows users have to fall back to stock, oversized windows scrollbars.