### PR TITLE
different behaviour of reset collection button

### DIFF
--- a/assets/js/inventory.js
+++ b/assets/js/inventory.js
@@ -3,6 +3,7 @@ var Inventory = {
   isPopupEnabled: $.cookie('inventory-popups-enabled') == '1',
   isMenuUpdateEnabled: $.cookie('inventory-menu-update-enabled') == '1',
   stackSize: parseInt($.cookie('inventory-stack')) ? parseInt($.cookie('inventory-stack')) : 10,
+  resetButtonChangingInventory: $.cookie('reset-changing-inventory-enabled') == '1',
 
   init: function () {
     if (typeof $.cookie('inventory-popups-enabled') === 'undefined') {
@@ -15,10 +16,16 @@ var Inventory = {
       $.cookie('inventory-menu-update-enabled', '1', { expires: 999 });
     }
 
+    if (typeof $.cookie('reset-changing-inventory-enabled') === 'undefined') {
+      Inventory.resetButtonChangingInventory = false;
+      $.cookie('reset-changing-inventory-enabled', '0', { expires: 999 });
+    }
+
     $('#enable-inventory').prop("checked", Inventory.isEnabled);
     $('#enable-inventory-popups').prop("checked", Inventory.isPopupEnabled);
     $('#enable-inventory-menu-update').prop("checked", Inventory.isMenuUpdateEnabled);
     $('#inventory-stack').val(Inventory.stackSize);
+    $('#reset-collection-changing-inventory').prop("checked", Inventory.resetButtonChangingInventory);
 
     this.toggleMenuItemsDisabled();
   },

--- a/assets/js/inventory.js
+++ b/assets/js/inventory.js
@@ -3,7 +3,7 @@ var Inventory = {
   isPopupEnabled: $.cookie('inventory-popups-enabled') == '1',
   isMenuUpdateEnabled: $.cookie('inventory-menu-update-enabled') == '1',
   stackSize: parseInt($.cookie('inventory-stack')) ? parseInt($.cookie('inventory-stack')) : 10,
-  resetButtonChangingInventory: $.cookie('reset-changing-inventory-enabled') == '1',
+  resetButtonUpdatesInventory: $.cookie('reset-updates-inventory-enabled') == '1',
 
   init: function () {
     if (typeof $.cookie('inventory-popups-enabled') === 'undefined') {
@@ -16,16 +16,16 @@ var Inventory = {
       $.cookie('inventory-menu-update-enabled', '1', { expires: 999 });
     }
 
-    if (typeof $.cookie('reset-changing-inventory-enabled') === 'undefined') {
-      Inventory.resetButtonChangingInventory = false;
-      $.cookie('reset-changing-inventory-enabled', '0', { expires: 999 });
+    if (typeof $.cookie('reset-updates-inventory-enabled') === 'undefined') {
+      Inventory.resetButtonUpdatesInventory = true;
+      $.cookie('reset-updates-inventory-enabled', '1', { expires: 999 });
     }
 
     $('#enable-inventory').prop("checked", Inventory.isEnabled);
     $('#enable-inventory-popups').prop("checked", Inventory.isPopupEnabled);
     $('#enable-inventory-menu-update').prop("checked", Inventory.isMenuUpdateEnabled);
+    $('#reset-collection-updates-inventory').prop("checked", Inventory.resetButtonUpdatesInventory);
     $('#inventory-stack').val(Inventory.stackSize);
-    $('#reset-collection-changing-inventory').prop("checked", Inventory.resetButtonChangingInventory);
 
     this.toggleMenuItemsDisabled();
   },

--- a/assets/js/scripts.js
+++ b/assets/js/scripts.js
@@ -450,16 +450,15 @@ $('.collection-reset').on('click', function (e) {
 
     if (inventory[value.text])
       inventory[value.text].isCollected = false;
-
+    
     value.isCollected = false;
     value.canCollect = true;
-
-    if (Inventory.isMenuUpdateEnabled) {
-      if (value.subdata)
-        Inventory.changeMarkerAmount(value.subdata, -1);
-      else
-        Inventory.changeMarkerAmount(value.text, -1);
-    }
+    
+    // .changeMarkerAmount() must run to check whether to remove "disabled" class
+    if (value.subdata) 
+      Inventory.changeMarkerAmount(value.subdata, (Inventory.isMenuUpdateEnabled ? -1 : 0));
+    else
+      Inventory.changeMarkerAmount(value.text, (Inventory.isMenuUpdateEnabled ? -1 : 0));
 
     $(this).removeClass('disabled');
   });

--- a/assets/js/scripts.js
+++ b/assets/js/scripts.js
@@ -453,12 +453,12 @@ $('.collection-reset').on('click', function (e) {
     
     value.isCollected = false;
     value.canCollect = true;
-    
+
     // .changeMarkerAmount() must run to check whether to remove "disabled" class
     if (value.subdata) 
-      Inventory.changeMarkerAmount(value.subdata, (Inventory.isMenuUpdateEnabled ? -1 : 0));
+      Inventory.changeMarkerAmount(value.subdata, (Inventory.resetButtonChangingInventory ? -1 : 0));
     else
-      Inventory.changeMarkerAmount(value.text, (Inventory.isMenuUpdateEnabled ? -1 : 0));
+      Inventory.changeMarkerAmount(value.text, (Inventory.resetButtonChangingInventory ? -1 : 0));
 
     $(this).removeClass('disabled');
   });
@@ -570,6 +570,11 @@ $('#enable-inventory-popups').on("change", function () {
 $('#enable-inventory-menu-update').on("change", function () {
   Inventory.isMenuUpdateEnabled = $("#enable-inventory-menu-update").prop('checked');
   $.cookie('inventory-menu-update-enabled', Inventory.isMenuUpdateEnabled ? '1' : '0', { expires: 999 });
+});
+
+$('#reset-collection-changing-inventory').on("change", function () {
+  Inventory.resetButtonChangingInventory = $('#reset-collection-changing-inventory').prop('checked');
+  $.cookie('reset-changing-inventory-enabled', Inventory.resetButtonChangingInventory ? '1' : '0', { expires: 999 });
 });
 
 if (Inventory.isEnabled)

--- a/assets/js/scripts.js
+++ b/assets/js/scripts.js
@@ -456,9 +456,9 @@ $('.collection-reset').on('click', function (e) {
 
     // .changeMarkerAmount() must run to check whether to remove "disabled" class
     if (value.subdata) 
-      Inventory.changeMarkerAmount(value.subdata, (Inventory.resetButtonChangingInventory ? -1 : 0));
+      Inventory.changeMarkerAmount(value.subdata, (Inventory.resetButtonUpdatesInventory ? -1 : 0));
     else
-      Inventory.changeMarkerAmount(value.text, (Inventory.resetButtonChangingInventory ? -1 : 0));
+      Inventory.changeMarkerAmount(value.text, (Inventory.resetButtonUpdatesInventory ? -1 : 0));
 
     $(this).removeClass('disabled');
   });
@@ -572,9 +572,9 @@ $('#enable-inventory-menu-update').on("change", function () {
   $.cookie('inventory-menu-update-enabled', Inventory.isMenuUpdateEnabled ? '1' : '0', { expires: 999 });
 });
 
-$('#reset-collection-changing-inventory').on("change", function () {
-  Inventory.resetButtonChangingInventory = $('#reset-collection-changing-inventory').prop('checked');
-  $.cookie('reset-changing-inventory-enabled', Inventory.resetButtonChangingInventory ? '1' : '0', { expires: 999 });
+$('#reset-collection-updates-inventory').on("change", function () {
+  Inventory.resetButtonUpdatesInventory = $('#reset-collection-updates-inventory').prop('checked');
+  $.cookie('reset-updates-inventory-enabled', Inventory.resetButtonUpdatesInventory ? '1' : '0', { expires: 999 });
 });
 
 if (Inventory.isEnabled)

--- a/assets/js/scripts.js
+++ b/assets/js/scripts.js
@@ -454,14 +454,14 @@ $('.collection-reset').on('click', function (e) {
     value.isCollected = false;
     value.canCollect = true;
 
-    if (value.subdata) {
-      Inventory.changeMarkerAmount(value.subdata, -1);
-      $(this).removeClass('disabled');
+    if (Inventory.isMenuUpdateEnabled) {
+      if (value.subdata)
+        Inventory.changeMarkerAmount(value.subdata, -1);
+      else
+        Inventory.changeMarkerAmount(value.text, -1);
     }
-    else {
-      Inventory.changeMarkerAmount(value.text, -1);
-      $(this).removeClass('disabled');
-    }
+
+    $(this).removeClass('disabled');
   });
   MapBase.save();
 });

--- a/index.html
+++ b/index.html
@@ -412,11 +412,11 @@
         </div>
       </div>
       <div class="input-container">
-        <label for="reset-collection-changing-inventory" data-text="menu.reset_button_changing_inventory">Reset collection button changing inventory</label>
+        <label for="reset-collection-updates-inventory" data-text="menu.reset_button_updates_inventory">Collection reset updates inventory</label>
         <div class="input-checkbox-wrapper">
-          <input class="input-checkbox" type="checkbox" name="reset-collection-changing-inventory" value="0"
-            id="reset-collection-changing-inventory" />
-          <label class="input-checkbox-label" for="reset-collection-changing-inventory"></label>
+          <input class="input-checkbox" type="checkbox" name="reset-collection-updates-inventory" value="0"
+            id="reset-collection-updates-inventory" />
+          <label class="input-checkbox-label" for="reset-collection-updates-inventory"></label>
         </div>
       </div>
       <div class="input-container">

--- a/index.html
+++ b/index.html
@@ -412,6 +412,14 @@
         </div>
       </div>
       <div class="input-container">
+        <label for="reset-collection-changing-inventory" data-text="menu.reset_button_changing_inventory">Reset collection button changing inventory</label>
+        <div class="input-checkbox-wrapper">
+          <input class="input-checkbox" type="checkbox" name="reset-collection-changing-inventory" value="0"
+            id="reset-collection-changing-inventory" />
+          <label class="input-checkbox-label" for="reset-collection-changing-inventory"></label>
+        </div>
+      </div>
+      <div class="input-container">
         <label for="inventory-stack" data-text="menu.inventory_stack">Item stack size</label>
         <input id="inventory-stack" class="input-day narrow-select-menu" type="number" min="1" max="10" value="10">
       </div>

--- a/langs/menu/en-us.json
+++ b/langs/menu/en-us.json
@@ -164,7 +164,7 @@
 	{"key": "alerts.file_not_found", "value": "Please select a file in the field above the import button, then try again."},
 	{"key": "alerts.feature_not_supported", "value": "This feature is not supported by your browser."},
 	{"key": "menu.enable_inventory_menu_update", "value": "Toggling menu items updates inventory"},
-	{"key": "menu.reset_button_changing_inventory", "value": "Reset collection button changing inventory"},
+	{"key": "menu.reset_button_updates_inventory", "value": "Collection reset updates inventory"},
 	{"key": "map.same_cycle_yesterday", "value": "This item has the same cycle as yesterday. In this case, there is a 24 hour delay to respawn the item."},
 
 	{"key": "menu.loot_table.category_arrowheads", "value": "Arrowheads"},

--- a/langs/menu/en-us.json
+++ b/langs/menu/en-us.json
@@ -164,6 +164,7 @@
 	{"key": "alerts.file_not_found", "value": "Please select a file in the field above the import button, then try again."},
 	{"key": "alerts.feature_not_supported", "value": "This feature is not supported by your browser."},
 	{"key": "menu.enable_inventory_menu_update", "value": "Toggling menu items updates inventory"},
+	{"key": "menu.reset_button_changing_inventory", "value": "Reset collection button changing inventory"},
 	{"key": "map.same_cycle_yesterday", "value": "This item has the same cycle as yesterday. In this case, there is a 24 hour delay to respawn the item."},
 
 	{"key": "menu.loot_table.category_arrowheads", "value": "Arrowheads"},


### PR DESCRIPTION
many ppl complained that reset button change inventory instead of only enable items.
if "Toggling menu items updates inventory" is disabled reset button don't affect the inventory

i will make another checkbox for this feature in the future, it will be more convenient