### PR TITLE
fixed wrong treasures sorting in different languages

### DIFF
--- a/assets/js/menu.js
+++ b/assets/js/menu.js
@@ -39,6 +39,7 @@ var Menu = {
 
       $('.menu-hidden[data-type=treasure]').append(collectibleElement.append(collectibleTextElement));
     });
+    Menu.reorderMenu('.menu-hidden[data-type=treasure]');
   }
 };
 
@@ -226,7 +227,6 @@ Menu.refreshMenu = function () {
     }
   });
 
-  Menu.reorderMenu('.menu-hidden[data-type=treasure]');
   Menu.refreshWeeklyItems();
 
   $('.map-cycle-alert span').html(Language.get('map.refresh_for_updates_alert'));

--- a/assets/js/scripts.js
+++ b/assets/js/scripts.js
@@ -13,7 +13,7 @@ var categories = [
 ];
 
 var categoriesDisabledByDefault = [
-  'treasure', 'random', 'treasure_hunter', 'tree_map', 'egg_encounter', 'dog_encounter', 'grave_robber',
+  'random', 'treasure_hunter', 'tree_map', 'egg_encounter', 'dog_encounter', 'grave_robber',
   'wounded_animal', 'rival_collector'
 ];
 


### PR DESCRIPTION
- fixed bug when after enabling any treasure the list became unordered (any language different than english)
- removed treasures from categories disabled by default (treasures in submenu are disabled - that's enough)