### PR TITLE
flowers soft stack size limit

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -878,7 +878,7 @@ a.wiki-page:visited {
 }
 
 .collection-collected {
-    min-width: 4.5rem;
+    min-width: 5.5rem;
 }
 
 /* Custom checkbox styling */

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -877,6 +877,10 @@ a.wiki-page:visited {
     opacity: .3;
 }
 
+.collection-collected {
+    min-width: 4.5rem;
+}
+
 /* Custom checkbox styling */
 
 .input-checkbox-wrapper {

--- a/assets/js/inventory.js
+++ b/assets/js/inventory.js
@@ -194,9 +194,9 @@ var Inventory = {
       if (Settings.isPopupsEnabled && marker.day == Cycles.categories[marker.category] && Layers.itemMarkersLayer.getLayerById(marker.text) != null)
         Layers.itemMarkersLayer.getLayerById(marker.text)._popup.setContent(MapBase.updateMarkerContent(marker));
 
-      if ((marker.isCollected || (InventorySettings.isEnabled && marker.amount >= InventorySettings.stackSize && marker.day == Cycles.categories[marker.category]) ||
+      if ((marker.isCollected || (InventorySettings.isEnabled && marker.amount >= InventorySettings.stackSize)) && marker.day == Cycles.categories[marker.category] ||
         // flowers soft stack size:
-        (marker.category === 'american_flowers' && marker.amount >= InventorySettings.flowersSoftStackSize))) {
+        (marker.category === 'american_flowers' && marker.amount >= InventorySettings.flowersSoftStackSize)) {
         $(`[data-marker=${marker.text}]`).css('opacity', Settings.markerOpacity / 3);
         $(`[data-type=${marker.subdata || marker.text}]`).addClass('disabled');
       }

--- a/assets/js/inventory.js
+++ b/assets/js/inventory.js
@@ -12,6 +12,7 @@ var Inventory = {
     $('#highlight_style').val(InventorySettings.highlightStyle);
     $('#inventory-container').toggleClass("opened", InventorySettings.isEnabled);
     $('#inventory-stack').val(InventorySettings.stackSize);
+    $('#soft-flowers-inventory-stack').val(InventorySettings.flowersSoftStackSize);
     $('#reset-collection-updates-inventory').prop("checked", InventorySettings.resetButtonUpdatesInventory);
     $('#reset-inventory-daily').prop("checked", InventorySettings.resetInventoryDaily);
   },
@@ -193,7 +194,9 @@ var Inventory = {
       if (Settings.isPopupsEnabled && marker.day == Cycles.categories[marker.category] && Layers.itemMarkersLayer.getLayerById(marker.text) != null)
         Layers.itemMarkersLayer.getLayerById(marker.text)._popup.setContent(MapBase.updateMarkerContent(marker));
 
-      if ((marker.isCollected || (InventorySettings.isEnabled && marker.amount >= InventorySettings.stackSize)) && marker.day == Cycles.categories[marker.category]) {
+      if ((marker.isCollected || (InventorySettings.isEnabled && marker.amount >= InventorySettings.stackSize && marker.day == Cycles.categories[marker.category]) ||
+        // flowers soft stack size:
+        (marker.category === 'american_flowers' && marker.amount >= InventorySettings.flowersSoftStackSize))) {
         $(`[data-marker=${marker.text}]`).css('opacity', Settings.markerOpacity / 3);
         $(`[data-type=${marker.subdata || marker.text}]`).addClass('disabled');
       }

--- a/assets/js/map.js
+++ b/assets/js/map.js
@@ -223,11 +223,9 @@ var MapBase = {
           markers[key].isCollected = false;
           markers[key].canCollect = markers[key].amount < InventorySettings.stackSize;
         }
-        else {
-          if (value.category === 'random') {
-            markers[key].isCollected = false;
-            markers[key].canCollect = true;
-          }
+        else if (value.category === 'random') {
+          markers[key].isCollected = false;
+          markers[key].canCollect = true;
         }
 
         if (InventorySettings.resetInventoryDaily) {

--- a/assets/js/map.js
+++ b/assets/js/map.js
@@ -212,7 +212,7 @@ var MapBase = {
 
     // Reset markers daily.
     var curDate = new Date();
-    date = curDate.toISOString().split('T')[0];
+    var date = curDate.toISOString().split('T')[0];
 
     if (localStorage.getItem('main.date') === null || date != localStorage.getItem('main.date')) {
       var markers = MapBase.markers;

--- a/assets/js/map.js
+++ b/assets/js/map.js
@@ -211,8 +211,7 @@ var MapBase = {
     uniqueSearchMarkers = MapBase.markers;
 
     // Reset markers daily.
-    var curDate = new Date();
-    var date = curDate.toISOString().split('T')[0];
+    var date = new Date().toISOString().split('T')[0];
 
     if (localStorage.getItem('main.date') === null || date != localStorage.getItem('main.date')) {
       var markers = MapBase.markers;

--- a/assets/js/map.js
+++ b/assets/js/map.js
@@ -212,7 +212,7 @@ var MapBase = {
 
     // Reset markers daily.
     var curDate = new Date();
-    date = curDate.getUTCFullYear() + '-' + (curDate.getUTCMonth() + 1) + '-' + curDate.getUTCDate();
+    date = curDate.toISOString().split('T')[0];
 
     if (localStorage.getItem('main.date') === null || date != localStorage.getItem('main.date')) {
       var markers = MapBase.markers;

--- a/assets/js/scripts.js
+++ b/assets/js/scripts.js
@@ -619,6 +619,13 @@ $('#inventory-stack').on("change", function () {
   InventorySettings.stackSize = inputValue;
 });
 
+// Flowers soft item stack size
+$('#soft-flowers-inventory-stack').on("change", function () {
+  var inputValue = parseInt($('#soft-flowers-inventory-stack').val());
+  inputValue = !isNaN(inputValue) ? inputValue : 10;
+  InventorySettings.flowersSoftStackSize = inputValue;
+});
+
 /**
  * Cookie import/exporting
  */

--- a/assets/js/settings.js
+++ b/assets/js/settings.js
@@ -160,6 +160,7 @@ Object.entries({
   resetButtonUpdatesInventory: { default: false },
   resetInventoryDaily: { default: false },
   stackSize: { default: 10 },
+  flowersSoftStackSize: { default: 10 },
 }).forEach(([name, config]) => SettingProxy.addSetting(InventorySettings, name, config));
 
 // Route settings

--- a/index.html
+++ b/index.html
@@ -619,6 +619,7 @@
             <option value="1" data-text="menu.marker_size.100" selected>100%</option>
             <option value="1.25" data-text="menu.marker_size.125">125%</option>
             <option value="1.5" data-text="menu.marker_size.150">150%</option>
+            <option value="1.75" data-text="menu.marker_size.175">175%</option>
           </select>
         </div>
         <div class="input-container" data-help="marker_opacity">

--- a/index.html
+++ b/index.html
@@ -505,12 +505,10 @@
           <label for="inventory-stack" data-text="menu.inventory_stack">Item stack size</label>
           <input id="inventory-stack" class="input-text narrow-select-menu" type="number" min="1" max="10" value="10">
         </div>
-
         <div class="input-container" data-help="soft_flowers_inventory_stack">
           <label for="soft-flowers-inventory-stack" data-text="menu.soft_flowers_inventory_stack">Flowers soft item stack size</label>
           <input id="soft-flowers-inventory-stack" class="input-text narrow-select-menu" type="number" min="1" max="10" value="10">
         </div>
-
         <div class="input-container" data-help="reset_inventory_daily">
           <label for="reset-inventory-daily" data-text="menu.reset_inventory_daily">Reset inventory daily</label>
           <div class="input-checkbox-wrapper">

--- a/index.html
+++ b/index.html
@@ -620,6 +620,7 @@
             <option value="1.25" data-text="menu.marker_size.125">125%</option>
             <option value="1.5" data-text="menu.marker_size.150">150%</option>
             <option value="1.75" data-text="menu.marker_size.175">175%</option>
+            <option value="2" data-text="menu.marker_size.200">200%</option>
           </select>
         </div>
         <div class="input-container" data-help="marker_opacity">

--- a/index.html
+++ b/index.html
@@ -505,6 +505,12 @@
           <label for="inventory-stack" data-text="menu.inventory_stack">Item stack size</label>
           <input id="inventory-stack" class="input-text narrow-select-menu" type="number" min="1" max="10" value="10">
         </div>
+
+        <div class="input-container" data-help="soft_flowers_inventory_stack">
+          <label for="soft-flowers-inventory-stack" data-text="menu.soft_flowers_inventory_stack">Flowers soft item stack size</label>
+          <input id="soft-flowers-inventory-stack" class="input-text narrow-select-menu" type="number" min="1" max="10" value="10">
+        </div>
+
         <div class="input-container" data-help="reset_inventory_daily">
           <label for="reset-inventory-daily" data-text="menu.reset_inventory_daily">Reset inventory daily</label>
           <div class="input-checkbox-wrapper">

--- a/index.html
+++ b/index.html
@@ -506,7 +506,7 @@
           <input id="inventory-stack" class="input-text narrow-select-menu" type="number" min="1" max="10" value="10">
         </div>
         <div class="input-container" data-help="soft_flowers_inventory_stack">
-          <label for="soft-flowers-inventory-stack" data-text="menu.soft_flowers_inventory_stack">Flowers soft item stack size</label>
+          <label for="soft-flowers-inventory-stack" data-text="menu.soft_flowers_inventory_stack">Flowers soft stack size</label>
           <input id="soft-flowers-inventory-stack" class="input-text narrow-select-menu" type="number" min="1" max="10" value="10">
         </div>
         <div class="input-container" data-help="reset_inventory_daily">

--- a/langs/menu/en-us.json
+++ b/langs/menu/en-us.json
@@ -192,6 +192,7 @@
 	"menu.marker_size.100": "100%",
 	"menu.marker_size.125": "125%",
 	"menu.marker_size.150": "150%",
+	"menu.marker_size.175": "175%",
 	"menu.toggle_debug": "Toggle debug features",
 	"map.random_spot.desc": "This spot gives you a random item, you can view more detailed information {link}.",
 	"map.random_spot.link": "on this Wiki page",

--- a/langs/menu/en-us.json
+++ b/langs/menu/en-us.json
@@ -232,7 +232,7 @@
 	"menu.custom_marker_dark_red": "Dark red",
 	"menu.custom_marker_dark_blue": "Dark blue",
 	"menu.reset_inventory_daily": "Reset inventory daily",
-	"menu.soft_flowers_inventory_stack": "Flowers soft item stack size",
+	"menu.soft_flowers_inventory_stack": "Flowers soft stack size",
 	"help.default": "Hover over or long-press (mobile) any setting to get information about it.",
 	"help.clear_custom_routes": "Clears all the custom routes currently on the map.",
 	"help.clear_inventory": "Clears all the items in the inventory.",

--- a/langs/menu/en-us.json
+++ b/langs/menu/en-us.json
@@ -193,6 +193,7 @@
 	"menu.marker_size.125": "125%",
 	"menu.marker_size.150": "150%",
 	"menu.marker_size.175": "175%",
+	"menu.marker_size.200": "200%",
 	"menu.toggle_debug": "Toggle debug features",
 	"map.random_spot.desc": "This spot gives you a random item, you can view more detailed information {link}.",
 	"map.random_spot.link": "on this Wiki page",

--- a/langs/menu/en-us.json
+++ b/langs/menu/en-us.json
@@ -232,6 +232,7 @@
 	"menu.custom_marker_dark_red": "Dark red",
 	"menu.custom_marker_dark_blue": "Dark blue",
 	"menu.reset_inventory_daily": "Reset inventory daily",
+	"menu.soft_flowers_inventory_stack": "Flowers soft item stack size",
 	"help.default": "Hover over or long-press (mobile) any setting to get information about it.",
 	"help.clear_custom_routes": "Clears all the custom routes currently on the map.",
 	"help.clear_inventory": "Clears all the items in the inventory.",
@@ -315,5 +316,6 @@
 	"help.highlight_low_amount_items": "Toggles whether the items with lowest amount in your inventory is highlighted on the map.",
 	"help.highlight_style": "Allows you to set the style how small item amounts are highlighted (static or animated highlights, recommended or default color theme)",
 	"help.collection_collected": "Amount of items collected for this collection.",
-	"help.reset_inventory_daily": "Toggles whether the inventory should be reset every 24 hours."
+	"help.reset_inventory_daily": "Toggles whether the inventory should be reset every 24 hours.",
+	"help.soft_flowers_inventory_stack": "Allows you to set \"soft\" limit of flowers in your inventory. When the limit is reached, flowers will be disabled from the map and in menu, but you can still add more flowers up to main stack size limit."
 }


### PR DESCRIPTION
- added soft inventory limit for flowers (next Ami's request) 
  - after the limit is reached flowers get disabled from the map and in menu but still can be more added up to main stack size 

- simplified function that reset markers daily
- restored marker size 175% and 200% for blind Ami
- fixed moving left and right "reset" and "sell" button after disabling the item