### PR TITLE
Make clickable area of category submenu button larger

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -526,7 +526,7 @@ select {
 .side-menu .menu-option-outer {
     position: relative;
     display: flex;
-    padding: 0 0 0 5px;
+    padding: 0 0 0 2px;
     user-select: none;
     cursor: pointer;
 }
@@ -564,7 +564,7 @@ select {
 }
 
 .side-menu .open-submenu {
-    min-width: 41px;
+    min-width: 42px;
     height: 38px;
     background: url(../images/arrow.png) center no-repeat;
     margin: auto 0;
@@ -666,6 +666,7 @@ select {
 .menu-option span {
     overflow: hidden;
     white-space: nowrap;
+    width: 275px;
     text-overflow: ellipsis;
 }
 

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -523,15 +523,21 @@ select {
     transition: all 200ms ease-out;
 }
 
+.side-menu .menu-option-outer {
+    position: relative;
+    display: flex;
+    padding: 0 0 0 5px;
+    user-select: none;
+    cursor: pointer;
+}
+
 .side-menu .menu-option {
     position: relative;
     display: flex;
     justify-content: space-between;
     align-items: start;
-    padding: 0 5px;
-    user-select: none;
-    cursor: pointer;
     line-height: 36px;
+    flex-grow: 1;
 }
 
 .side-menu .disabled {
@@ -558,7 +564,7 @@ select {
 }
 
 .side-menu .open-submenu {
-    min-width: 32px;
+    min-width: 41px;
     height: 38px;
     background: url(../images/arrow.png) center no-repeat;
     margin: auto 0;
@@ -1524,7 +1530,7 @@ a.no-style:visited {
 @media (min-width: 1025px) {
 
     .settings-container .input-container:not(.disabled):after,
-    .side-menu .menu-option:after,
+    .side-menu .menu-option-outer:after,
     .side-menu .collectible-wrapper:after {
         border-color: #d80419;
         border-image-repeat: round;
@@ -1543,7 +1549,7 @@ a.no-style:visited {
         z-index: 10;
     }
 
-    .side-menu .menu-option:after,
+    .side-menu .menu-option-outer:after,
     .side-menu .collectible-wrapper:after {
         top: 1px;
         right: 2px;
@@ -1552,7 +1558,7 @@ a.no-style:visited {
     }
 
     .settings-container .input-container:not(.disabled):hover:after,
-    .side-menu .menu-option:hover:after,
+    .side-menu .menu-option-outer:hover:after,
     .side-menu .collectible-wrapper:hover:after {
         opacity: 1;
     }

--- a/assets/js/items.js
+++ b/assets/js/items.js
@@ -216,18 +216,20 @@ class Collection extends BaseCollection {
   _insertMenuElement() {
     const $element = $(`
       <div>
-        <div class="menu-option clickable" data-type="${this.category}" data-help="item_category">
-          <span>
-            <img class="icon" src="assets/images/icons/${this.category}.png" alt="${this.category}">
+        <div class="menu-option-outer" data-help="item_category">
+          <div class="menu-option clickable" data-type="${this.category}">
             <span>
-              <span class="menu-option-text" data-text="menu.${this.category}"></span>
-              <img class="same-cycle-warning-menu" src="assets/images/same-cycle-alert.png">
+              <img class="icon" src="assets/images/icons/${this.category}.png" alt="${this.category}">
+              <span>
+                <span class="menu-option-text" data-text="menu.${this.category}"></span>
+                <img class="same-cycle-warning-menu" src="assets/images/same-cycle-alert.png">
+              </span>
             </span>
-          </span>
-          <input class="input-text input-cycle" type="number" min="1" max="6"
-            name="${this.category}" data-help="item_manual_cycle">
-          <img class="cycle-icon" src="assets/images/cycle_1.png" alt="Cycle 1"
-            data-type="${this.category}">
+            <input class="input-text input-cycle" type="number" min="1" max="6"
+              name="${this.category}" data-help="item_manual_cycle">
+            <img class="cycle-icon" src="assets/images/cycle_1.png" alt="Cycle 1"
+              data-type="${this.category}">
+          </div>
           <div class="open-submenu"></div>
         </div>
         <div class="menu-hidden" data-type="${this.category}">


### PR DESCRIPTION
I mainly use the map on a tablet, and one minor issue is that when hitting the button to "open/close category submenu", sometimes it triggers the "enable/disable category" effect instead.

After doing some experiment on a PC with mouse, it seems that when the mouse click is on the right border line for the category, it triggers "enable/disable category" rather than "open/close submenu", which might be what happens on the tablet with the issue mentioned above (i.e., when it considers the finger touch to be a click on the right border line).

This commit tries to address this issue by taking `open-submenu` out of `menu-option` and putting both into an outer container. Differences from before are:
- Visually the only difference I see is that the "cycle icon" moves slightly to the left (submenu button gets a little more padding).
- Behavior-wise, the "clickable area" for the submenu button becomes slightly larger on both the left side (due to padding) and the right side (now including the right border line).

Please check if this can be applied or if there is a better way. Thanks!