### PR TITLE
Make submenu button click behaviors more tolerant for touch interface

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -462,7 +462,7 @@ select {
 }
 
 .input-text.input-cycle.random {
-    margin-right: 47px;
+    margin-right: 52px;
 }
 
 .issues-container a {
@@ -853,7 +853,7 @@ a.wiki-page:visited {
 }
 
 .cycle-icon.random {
-    margin-right: 53px;
+    margin-right: 58px;
 }
 
 .marker-content-wrapper {

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -513,15 +513,22 @@ select {
     transition: all 200ms ease-out;
 }
 
+.side-menu .menu-option-outer {
+    position: relative;
+    display: flex;
+    padding: 0;
+    user-select: none;
+    cursor: pointer;
+}
+
 .side-menu .menu-option {
     position: relative;
     display: flex;
     justify-content: space-between;
     align-items: start;
-    padding: 0 5px;
-    user-select: none;
-    cursor: pointer;
+    padding: 0 0 0 5px;
     line-height: 36px;
+    flex-grow: 1;
 }
 
 .side-menu .disabled {
@@ -548,10 +555,10 @@ select {
 }
 
 .side-menu .open-submenu {
-    min-width: 42px;
+    min-width: 52px;
     height: 38px;
     background: url(../images/arrow.png) center no-repeat;
-    margin: auto 0 auto 5px;
+    margin: auto 0;
     padding: 0;
 }
 
@@ -1521,7 +1528,7 @@ a.no-style:visited {
 @media (min-width: 1025px) {
 
     .settings-container .input-container:not(.disabled):after,
-    .side-menu .menu-option:after,
+    .side-menu .menu-option-outer:after,
     .side-menu .collectible-wrapper:after {
         border-color: #d80419;
         border-image-repeat: round;
@@ -1540,7 +1547,7 @@ a.no-style:visited {
         z-index: 10;
     }
 
-    .side-menu .menu-option:after,
+    .side-menu .menu-option-outer:after,
     .side-menu .collectible-wrapper:after {
         top: 1px;
         right: 2px;
@@ -1549,7 +1556,7 @@ a.no-style:visited {
     }
 
     .settings-container .input-container:not(.disabled):hover:after,
-    .side-menu .menu-option:hover:after,
+    .side-menu .menu-option-outer:hover:after,
     .side-menu .collectible-wrapper:hover:after {
         opacity: 1;
     }

--- a/assets/js/items.js
+++ b/assets/js/items.js
@@ -216,18 +216,20 @@ class Collection extends BaseCollection {
   _insertMenuElement() {
     const $element = $(`
       <div>
-        <div class="menu-option clickable" data-type="${this.category}" data-help="item_category">
-          <span>
-            <img class="icon" src="assets/images/icons/${this.category}.png" alt="${this.category}">
+        <div class="menu-option-outer" data-help="item_category">
+          <div class="menu-option clickable" data-type="${this.category}">
             <span>
-              <span class="menu-option-text" data-text="menu.${this.category}"></span>
-              <img class="same-cycle-warning-menu" src="assets/images/same-cycle-alert.png">
+              <img class="icon" src="assets/images/icons/${this.category}.png" alt="${this.category}">
+              <span>
+                <span class="menu-option-text" data-text="menu.${this.category}"></span>
+                <img class="same-cycle-warning-menu" src="assets/images/same-cycle-alert.png">
+              </span>
             </span>
-          </span>
-          <input class="input-text input-cycle" type="number" min="1" max="6"
-            name="${this.category}" data-help="item_manual_cycle">
-          <img class="cycle-icon" src="assets/images/cycle_1.png" alt="Cycle 1"
-            data-type="${this.category}">
+            <input class="input-text input-cycle" type="number" min="1" max="6"
+              name="${this.category}" data-help="item_manual_cycle">
+            <img class="cycle-icon" src="assets/images/cycle_1.png" alt="Cycle 1"
+              data-type="${this.category}">
+          </div>
           <div class="open-submenu"></div>
         </div>
         <div class="menu-hidden" data-type="${this.category}">

--- a/index.html
+++ b/index.html
@@ -95,44 +95,54 @@
           </span>
           <input class="input-text input-cycle random" type="number" min="1" max="6" name="random" data-help="item_manual_cycle">
           <img class="cycle-icon random" src="./assets/images/cycle_3.png" alt="Cycle 3" data-type="random">
-      </div>
+        </div>
       </div>
     </div>
 
     <div id="utilities-container">
       <h2 data-text="menu.utils">Utilities</h2>
-      <div class="menu-option clickable" data-type="nazar" data-help="item_category">
-        <span>
-          <img class="icon" src="./assets/images/icons/nazar.png" alt="Category icon" />
-          <span class="menu-option-text" data-text="menu.madam_nazar">Madam Nazar</span>
-        </span>
+      <div class="menu-option-outer" data-help="item_category">
+        <div class="menu-option clickable" data-type="nazar">
+          <span>
+            <img class="icon" src="./assets/images/icons/nazar.png" alt="Category icon" />
+            <span class="menu-option-text" data-text="menu.madam_nazar">Madam Nazar</span>
+          </span>
+        </div>
       </div>
-      <div class="menu-option clickable" data-type="fast_travel" data-help="item_category">
-        <span>
-          <img class="icon" src="./assets/images/icons/fast_travel.png" alt="Category icon" />
-          <span class="menu-option-text" data-text="menu.fast_travel">Fast Travel</span>
-        </span>
+      <div class="menu-option-outer" data-help="item_category">
+        <div class="menu-option clickable" data-type="fast_travel">
+          <span>
+            <img class="icon" src="./assets/images/icons/fast_travel.png" alt="Category icon" />
+            <span class="menu-option-text" data-text="menu.fast_travel">Fast Travel</span>
+          </span>
+        </div>
       </div>
-      <div class="menu-option clickable" data-type="user_pins" data-help="item_category">
-        <span>
-          <img class="icon" src="./assets/images/icons/pins.png" alt="Category icon" />
-          <span class="menu-option-text" data-text="menu.user_pins">User Pins</span>
-        </span>
+      <div class="menu-option-outer" data-help="item_category">
+        <div class="menu-option clickable" data-type="user_pins">
+          <span>
+            <img class="icon" src="./assets/images/icons/pins.png" alt="Category icon" />
+            <span class="menu-option-text" data-text="menu.user_pins">User Pins</span>
+          </span>
+        </div>
       </div>
       <a class="no-style" href="https://jeanropke.github.io/RDOMap/" target="_blank">
-        <div class="menu-option">
-          <span>
-            <img class="icon" src="./assets/images/icons/random_encounter.png" alt="Category icon" />
-            <span class="menu-option-text" data-text="menu.random_encounters">Random Encounters</span>
-          </span>
+        <div class="menu-option-outer">
+          <div class="menu-option">
+            <span>
+              <img class="icon" src="./assets/images/icons/random_encounter.png" alt="Category icon" />
+              <span class="menu-option-text" data-text="menu.random_encounters">Random Encounters</span>
+            </span>
+          </div>
         </div>
       </a>
       <div>
-        <div class="menu-option clickable" data-type="treasure" data-help="item_category">
-          <span>
-            <img class="icon" src="./assets/images/icons/treasure.png" alt="Category icon" />
-            <span class="menu-option-text" data-text="menu.treasures">Treasures</span>
-          </span>
+        <div class="menu-option-outer" data-help="item_category">
+          <div class="menu-option clickable" data-type="treasure">
+            <span>
+              <img class="icon" src="./assets/images/icons/treasure.png" alt="Category icon" />
+              <span class="menu-option-text" data-text="menu.treasures">Treasures</span>
+            </span>
+          </div>
           <div class="open-submenu" style="margin: auto 0 auto auto;"></div>
         </div>
         <div class="menu-hidden" data-type="treasure">

--- a/index.html
+++ b/index.html
@@ -87,13 +87,15 @@
     </div>
 
     <div id="collection-insertion-before-point">
-      <div class="menu-option clickable" data-type="random" data-help="item_category">
-        <span>
-          <img class="icon" src="./assets/images/icons/random.png" alt="Category icon" />
-          <span class="menu-option-text" data-text="menu.random_spots">Random Spots</span>
-        </span>
-        <input class="input-text input-cycle random" type="number" min="1" max="6" name="random" data-help="item_manual_cycle">
-        <img class="cycle-icon random" src="./assets/images/cycle_3.png" alt="Cycle 3" data-type="random">
+      <div class="menu-option-outer" data-help="item_category">
+        <div class="menu-option clickable" data-type="random">
+          <span>
+            <img class="icon" src="./assets/images/icons/random.png" alt="Category icon" />
+            <span class="menu-option-text" data-text="menu.random_spots">Random Spots</span>
+          </span>
+          <input class="input-text input-cycle random" type="number" min="1" max="6" name="random" data-help="item_manual_cycle">
+          <img class="cycle-icon random" src="./assets/images/cycle_3.png" alt="Cycle 3" data-type="random">
+      </div>
       </div>
     </div>
 


### PR DESCRIPTION
As discussed in #1027, originally (up to 6578c37) the click behaviors around the submenu button can be divided into four regions (dividing lines are approximate, not pixel-precise):
<img width="365" alt="orig-act-2" src="https://user-images.githubusercontent.com/3876934/85981496-22035500-b999-11ea-9738-fbc1b7e2be73.png">
1. Category enable/disable
2. Submenu open/close
3. Category enable/disable
4. Scrollbar

The latest changes (up to 0cc09d7) removed the scrollbar and made some other improvements, so now there are only three regions:
<img width="374" alt="noscroll-act-2" src="https://user-images.githubusercontent.com/3876934/85981565-42cbaa80-b999-11ea-81c1-5b5e6f6640c7.png">
1. Category enable/disable
2. Submenu open/close
3. Category enable/disable

As mentioned in the previous PR, on a tablet, sometimes one would accidentally hit (3) (or even (4) in the original case) while aiming for (2) when the finger touch "leans to the right". (Of course this is not really an issue on PC with a mouse because the click is precise.)

The commit in this PR further simplifies the behaviors to only two regions:
<img width="374" alt="new-act-2" src="https://user-images.githubusercontent.com/3876934/85981620-5bd45b80-b999-11ea-9af7-b8a4f1e775ed.png">
1. Category enable/disable
2. Submenu open/close

This should make it more "tolerant" on a touch interface, i.e., less likely to produce unexpected result.