### PR TITLE
categories: have even randoms included as visible by default

### DIFF
--- a/assets/js/scripts.js
+++ b/assets/js/scripts.js
@@ -34,11 +34,7 @@ const parentCategories = {
   fossils_random: ['coastal', 'megafauna', 'oceanic']
 };
 
-let enabledCategories = JSON.parse(localStorage.getItem("enabled-categories"));
-if (!enabledCategories) {
-  const disabledCats = JSON.parse(localStorage.getItem("disabled-categories")) || ['random'];
-  enabledCategories = categories.filter(item => !disabledCats.includes(item));
-}
+let enabledCategories = JSON.parse(localStorage.getItem("enabled-categories")) || [...categories];
 
 /*
 - Leaflet extentions require Leaflet loaded


### PR DESCRIPTION
* also remove compatibility code which is phased out now
  * (i.e. reading of `disabled-categories`)