### PR TITLE
Skip items collected ahead in the route

### DIFF
--- a/assets/js/pathfinder.main.js
+++ b/assets/js/pathfinder.main.js
@@ -170,8 +170,13 @@ class PathFinder {
 	}
 
 	static wasRemovedFromMap(marker) {
-		if(this._layerControl && this._layerControl._lastMarker === marker) {
-			this._layerControl.selectPath(1)
+		if(this._layerControl && this._layerControl._lastMarker === marker && marker.isCollected) {
+			this._layerControl.selectPath(1);
+
+			// Skip the markers that are already collected ahead, unless already in the end of route
+			while (this._layerControl && this._layerControl._lastMarker.isCollected && this._layerControl.currentPath !== this._layerControl._paths.length) {
+				this._layerControl.selectPath(1);
+			}
 		}
 	}
 


### PR DESCRIPTION
When adding/removing currently active route item from the map, only
select next path if it was removed, not added back.

If next markers are already marked as collected, skip them to first path that goes to
uncollected marker, or to the end of the route.

See https://github.com/jeanropke/RDR2CollectorsMap/issues/1132 for discussion