### PR TITLE
Add feature 'Completely hide removed markers'

### DIFF
--- a/assets/js/marker.js
+++ b/assets/js/marker.js
@@ -407,8 +407,15 @@ class Marker {
       .end()
       .find('img.background').attr('src', bgUrl);
   }
-  updateOpacity(opacity = Settings.markerOpacity) {
-    this.lMarker && this.lMarker.setOpacity(this.canCollect ? opacity : opacity / 3);
+  updateOpacity(opacity = Settings.markerOpacity, isInvisibleRemovedMarkers = Settings.isInvisibleRemovedMarkers) {
+    let targetOpacity;
+    if (this.canCollect) {
+      targetOpacity = opacity;
+    } else {
+      targetOpacity = (isInvisibleRemovedMarkers? 0: opacity / 3);
+    }
+
+    this.lMarker && this.lMarker.setOpacity(targetOpacity);
   }
   recreateLMarker(isShadowsEnabled = Settings.isShadowsEnabled, markerSize = Settings.markerSize) {
     const icon = this.category !== 'random' ? this.category : (this.tool === 1 ? 'shovel' : 'magnet');

--- a/assets/js/marker.js
+++ b/assets/js/marker.js
@@ -412,7 +412,7 @@ class Marker {
     if (this.canCollect) {
       targetOpacity = opacity;
     } else {
-      targetOpacity = (isInvisibleRemovedMarkers? 0: opacity / 3);
+      targetOpacity = isInvisibleRemovedMarkers ? 0 : opacity / 3;
     }
 
     this.lMarker && this.lMarker.setOpacity(targetOpacity);

--- a/assets/js/scripts.js
+++ b/assets/js/scripts.js
@@ -520,6 +520,11 @@ $("#marker-opacity").on("change", function () {
   MapBase.addMarkers();
 });
 
+$("#invisible-removed-markers").on("change", function () {
+  Settings.isInvisibleRemovedMarkers = $("#invisible-removed-markers").prop("checked");
+  MapBase.addMarkers();
+});
+
 $("#marker-size").on("change", function () {
   Settings.markerSize = Number($("#marker-size").val());
   MapBase.addMarkers();

--- a/assets/js/settings.js
+++ b/assets/js/settings.js
@@ -161,6 +161,7 @@ Object.entries({
   isLaBgEnabled: { default: true },
   isMapBoundariesEnabled: {default: true },
   markerOpacity: { default: 1 },
+  isInvisibleRemovedMarkers: { default: false },
   markerSize: { default: 1 },
   overlayOpacity: { default: 0.5 },
   resetMarkersDaily: { default: true },

--- a/index.html
+++ b/index.html
@@ -561,7 +561,7 @@
           </select>
         </div>
         <div class="input-container" data-help="invisible-removed-markers">
-          <label for="invisible-removed-markers" data-text="menu.invisible-removed-markers">Map boundaries enabled</label>
+          <label for="invisible-removed-markers" data-text="menu.invisible-removed-markers">Completely hide removed markers</label>
           <div class="input-checkbox-wrapper">
             <input class="input-checkbox" type="checkbox" name="invisible-removed-markers" value="1" id="invisible-removed-markers" />
             <label class="input-checkbox-label" for="invisible-removed-markers"></label>

--- a/index.html
+++ b/index.html
@@ -560,6 +560,13 @@
             <option value="1" data-text="menu.marker_opacity.100" selected>Opaque</option>
           </select>
         </div>
+        <div class="input-container" data-help="invisible-removed-markers">
+          <label for="invisible-removed-markers" data-text="menu.invisible-removed-markers">Map boundaries enabled</label>
+          <div class="input-checkbox-wrapper">
+            <input class="input-checkbox" type="checkbox" name="invisible-removed-markers" value="1" id="invisible-removed-markers" />
+            <label class="input-checkbox-label" for="invisible-removed-markers"></label>
+          </div>
+        </div>
         <div class="input-container" data-help="marker_cluster">
           <label for="marker-cluster" data-text="menu.marker_cluster">Markers cluster</label>
           <div class="input-checkbox-wrapper">
@@ -1269,7 +1276,7 @@
       </div>
     </div>
   </div>
-  
+
   <div class="modal fade" id="import-rdo-inventory-modal" tabindex="-1" role="dialog" aria-labelledby="import-rdo-inventory-modal-title">
     <div class="modal-dialog modal-updates" role="document">
       <div class="modal-content">

--- a/langs/en.json
+++ b/langs/en.json
@@ -1633,6 +1633,8 @@
     "menu.marker_size.150": "150%",
     "menu.marker_size.175": "175%",
     "menu.marker_size.200": "200%",
+    "help.invisible-removed-markers": "Completely hides removed markers instead of making it partially transparent.",
+    "menu.invisible-removed-markers": "Completely hide removed markers",
     "menu.toggle_debug": "Toggle debug features",
     "map.random_spot.desc": "This spot gives you a random item, you can view more detailed information {int.random_spot.link}on this Wiki page{int.end.link}.",
     "map.attribution_prefix": "Collectors Map Contributors",

--- a/langs/ko.json
+++ b/langs/ko.json
@@ -1432,6 +1432,8 @@
     "menu.marker_size.150": "150%",
     "menu.marker_size.175": "175%",
     "menu.marker_size.200": "200%",
+    "help.invisible-removed-markers": "지도에서 제거된 마커를 투명하게 만드는 대신 완전히 숨깁니다.",
+    "menu.invisible-removed-markers": "제거된 마커 숨김",
     "menu.toggle_debug": "디버그 기능 사용",
     "map.random_spot.desc": "이 지점은 랜덤 항목을 제공합니다. 자세한 정보를 참조하려면 {int.random_spot.link}위키 페이지{int.end.link}에서 확인할 수 있습니다.",
     "map.attribution_prefix": "수집가 지도 제공자",


### PR DESCRIPTION
It implements #1183.
![image](https://user-images.githubusercontent.com/66462458/165888732-1b346201-f14d-46e1-bf92-0670ae21ed10.png)

[The previous PR](https://github.com/jeanropke/RDR2CollectorsMap/pull/1203) tried to commit with `LF` but it seems to use `CRLF`, and so did I this time.