### PR TITLE
Fix language codes mapping for Chinese-speaking users

### DIFF
--- a/assets/js/scripts.js
+++ b/assets/js/scripts.js
@@ -113,8 +113,17 @@ function init() {
   }
 
   const navLang = navigator.language;
-  SettingProxy.addSetting(Settings, 'language', {
-    default: Language.availableLanguages.includes(navLang) ? navLang : 'en',
+  const langCodesMap = {
+    "zh-CN": "zh-Hans",
+    "zh-SG": "zh-Hans",
+    "zh-HK": "zh-Hant",
+    "zh-TW": "zh-Hant",
+  };
+  const mappedLanguage = langCodesMap[navLang] || navLang;
+  SettingProxy.addSetting(Settings, "language", {
+    default: Language.availableLanguages.includes(mappedLanguage)
+      ? mappedLanguage
+      : "en",
   });
 
   Settings.language = Language.availableLanguages.includes(Settings.language) ? Settings.language : 'en';


### PR DESCRIPTION
#1230 
It turned out that `'zh-Hans'` and `'zh-Hant'` are not the standard language codes, it is supposed to be `'zh-CN'` or `'zh-TW'`.