### PR TITLE
Fix: behavior issue with type filter when the search is complete and toggling categories

### DIFF
--- a/assets/js/map.js
+++ b/assets/js/map.js
@@ -418,8 +418,8 @@ const MapBase = {
       ];
 
       if (!searchTerms.length) {
-        uniqueSearchMarkers = MapBase.markers;
-        MapBase.addMarkers();
+        if (Settings.filterType !== 'none') $('#filter-type').val(Settings.filterType);
+        filterMapMarkers();
         return;
       }
 

--- a/assets/js/menu.js
+++ b/assets/js/menu.js
@@ -168,7 +168,7 @@ class Menu {
               Legendary.onCategoryToggle();
               break;
           }
-        } else if (Settings.isDebugEnabled) {
+        } else if (Settings.toolType !== 3 || Settings.filterType !== 'none' || $('#search').val() || Settings.isDebugEnabled) {
             MapBase.addMarkers();
         } else if (parentCategories['fossils_random'].includes(category)) {
             const markers = MapBase.markers.filter(marker => marker.cycleName == Cycles.categories[category] && marker.category === 'fossils_random');


### PR DESCRIPTION
Hello,
Fixing a little legacy bug. 
To reproduce:
when the filter value is non-`none`, performing a search and then clearing the search input resets the displayed filter-type on the menu to `none`, and an alert at the bottom indicates that it retains the previous value."

Additionally, there's another issue where markers from previous searches persist on the map after search completion, although I'm uncertain whether to classify it as a bug.
To reproduce:
`Hide all` - select `Moonshiner` on marker filter - search keywords`ring` - click "X" to abort or delete input queries - set filter type to `none`
The searching results are still on the map.